### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ To install and setup pm2-discord-webhook, run the following commands:
 
 ```
 pm2 install pm2-discord-webhook
-pm2 set pm2-discord-webhook:discord_url_logs https://discord_url
-pm2 set pm2-discord-webhook:discord_url_errors https://discord_url
+pm2 set pm2-discord-webhook:webhook_url_logs https://discord_url
+pm2 set pm2-discord-webhook:webhook_url_errors https://discord_url
 ```
 
 #### `discord_url`


### PR DESCRIPTION
it looks like the author made a typo
script uses `webhook_url_logs` & `webhook_url_errors`
not a `discord_url_logs` & `discord_url_errors`